### PR TITLE
Proposed change to adoption process to provide change-marked copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ git checkout -b bracz-adopt-foo-standard
   - In menu > File > Properties > Custom Properties, set OlcbStatus to Adopted,
     the date, and the year as a range up till now, e.g. 2013-2021.
   - menu > Format > Watermark..., replace the DRAFT text with a single space.
+  - Make sure that View -> Show Tracked Changes is still on at this point.
 
 4. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
    output.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ git push
   This step can only be done by a maintainer -- ask someone on the
   openlcb@groups.io list.
 
-1. Create a new brach:
+1. Create a new branch:
 
 ```
 git checkout master
@@ -132,21 +132,32 @@ git pull
 git checkout -b bracz-adopt-foo-standard
 ```
 
-1. Update the ODT file for adopted.
+1. Update the ODT file to mark it as adoped
+
+  - In menu > File > Properties > Custom Properties, set OlcbStatus to Adopted,
+    the date, and the year as a range up till now, e.g. 2013-2021.
+  - menu > Format > Watermark..., replace the DRAFT text with a single space.
+
+  - Do not accept changes at this point.
+  
+2. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
+   output.
+
+  - This creates a PDF file with changes marked.  Move that to the 
+    standards/changes directory. Add it and commit it to your branch.
+    
+3. Update the ODT file to remove change markers
 
   - Review all changes in menu > Edit > Track Changes > Manage...
   - Accept all changes. There should be no changes left in the Manage changes
     dialog.
-  - In menu > File > Properties > Custom Properties, set OlcbStatus to Adopted,
-    the date, and the year as a range up till now, e.g. 2013-2021.
-  - menu > Format > Watermark..., replace the DRAFT text with a single space.
     
-2. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
+4. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
    output.
    
-3. Commit the odt, pdf, txt files to your branch.
+5. Commit the odt, pdf, txt files to your branch.
 
-4. Delete the files from the standards directory. This step should be skipped
+6. Delete the files from the standards directory. This step should be skipped
    if we are adopting a standard the first time, and there are no previous
    adopted files.
 
@@ -156,9 +167,9 @@ git rm standards/FooStandardS.pdf
 git rm standards/generated/FooStandardS.txt
 ```
 
-5. Commit these to your branch.
+7. Commit these to your branch.
 
-6. Move the files from draft to standards.
+8. Move the files from draft to standards.
 
 ```
 git mv {drafts,standards}/FooStandardS.odt
@@ -166,11 +177,11 @@ git mv {drafts,standards}/FooStandardS.pdf
 git mv {drafts,standards}/generated/FooStandardS.txt
 ```
 
-7. Commit these to your branch.
+9. Commit these to your branch.
 
-8. Create a PR with your changes on GitHub. Ask a maintainer to review the PR.
+10. Create a PR with your changes on GitHub. Ask a maintainer to review the PR.
 
-9. IMPORTANT: The PR must be merged with a "Create a merge commit" option.
+11. IMPORTANT: The PR must be merged with a "Create a merge commit" option.
 
 ## Docker
 A Docker image file has been added to provide a consistent file conversion processing environment in a Docker Container.

--- a/README.md
+++ b/README.md
@@ -132,33 +132,38 @@ git pull
 git checkout -b bracz-adopt-foo-standard
 ```
 
-1. Update the ODT file to mark it as adoped
+2. Check the changes for gross errors
+
+  - Review all changes in menu > Edit > Track Changes > Manage...
+  - Do not accept changes at this point.
+
+3. Update the ODT file to mark it as adopted
 
   - In menu > File > Properties > Custom Properties, set OlcbStatus to Adopted,
     the date, and the year as a range up till now, e.g. 2013-2021.
   - menu > Format > Watermark..., replace the DRAFT text with a single space.
 
-  - Do not accept changes at this point.
-  
-2. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
-   output.
-
-  - This creates a PDF file with changes marked.  Move that to the 
-    standards/changes directory. Add it and commit it to your branch.
-    
-3. Update the ODT file to remove change markers
-
-  - Review all changes in menu > Edit > Track Changes > Manage...
-  - Accept all changes. There should be no changes left in the Manage changes
-    dialog.
-    
 4. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
    output.
-   
-5. Commit the odt, pdf, txt files to your branch.
 
-6. Delete the files from the standards directory. This step should be skipped
-   if we are adopting a standard the first time, and there are no previous
+  - This creates a PDF file with changes marked.  Copy that to the 
+    standards/changes directory. Name it with the date, 
+    e.g. FooStandardS-changes-2024-07-22.pdf
+  - Add that copy and commit it to your branch.
+    
+5. Update the ODT file to remove change markers
+
+  - Accept all changes. There should be no changes left in the Manage changes
+    dialog.
+  - Check for comment bubbles.  If any are found, remove them.
+    
+6. Save the ODT file, quit openoffice. Run `make` to generate the PDF and TXT
+   output.
+   
+7. Commit the odt, pdf, txt files to your branch.
+
+8. Delete the files from the standards directory. This step should be skipped
+   if we are adopting a document for the first time, and there are no previous
    adopted files.
 
 ```
@@ -167,9 +172,9 @@ git rm standards/FooStandardS.pdf
 git rm standards/generated/FooStandardS.txt
 ```
 
-7. Commit these to your branch.
+9. Commit these to your branch.
 
-8. Move the files from draft to standards.
+10. Move the files from draft to standards.
 
 ```
 git mv {drafts,standards}/FooStandardS.odt
@@ -177,11 +182,11 @@ git mv {drafts,standards}/FooStandardS.pdf
 git mv {drafts,standards}/generated/FooStandardS.txt
 ```
 
-9. Commit these to your branch.
+11. Commit these to your branch.
 
-10. Create a PR with your changes on GitHub. Ask a maintainer to review the PR.
+12. Create a PR with your changes on GitHub. Ask a maintainer to review the PR.
 
-11. IMPORTANT: The PR must be merged with a "Create a merge commit" option.
+13. IMPORTANT: The PR must be merged with a "Create a merge commit" option.
 
 ## Docker
 A Docker image file has been added to provide a consistent file conversion processing environment in a Docker Container.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ git checkout -b bracz-adopt-foo-standard
   - This creates a PDF file with changes marked.  Copy that to the 
     standards/changes directory. Name it with the date, 
     e.g. FooStandardS-changes-2024-07-22.pdf
-  - Add that copy and commit it to your branch.
+  - Add that copy and commit it with all other changed files (odt, pdf, txt) to
+    your branch.
     
 5. Update the ODT file to remove change markers
 

--- a/standards/changes/README.md
+++ b/standards/changes/README.md
@@ -1,0 +1,3 @@
+This directory contains versions of adopted OpenLCB documents where the changes since the previous adopted version have been marked.
+
+The documents in the parent standards/ directory are the official adopted versions.


### PR DESCRIPTION
This adds steps to the document-adoption process to create and keep a copy of the document with changes marked.

That marked copy is stored in a new `standards/changes` directory, which this PR creates.